### PR TITLE
track bump progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ Currently, the only supported release is [rolling](https://github.com/cachix/dev
 Rolling is based upon [nixpkgs-unstable](https://github.com/NixOS/nixpkgs/tree/nixpkgs-unstable)
 plus a few patches that [devenv](https://github.com/cachix/devenv) needs which have not yet reached upstream:
 
-- python3Packages.deepdiff: disable tests
-- dnspython: disable tests
-- openldap: tests fail on darwin
-- [fix meiliesearch on darwin](285676e87ad9f0ca23d8714a6ab61e7e027020c6)
+All patches have been upstreamed to nixpkgs!
 
 You can check the latest [tests here](https://github.com/cachix/devenv-nixpkgs/actions).
 


### PR DESCRIPTION
https://github.com/cachix/devenv/pull/1489

- [ ] terraform on macOS. Our nix test command is segfaulting...
- [x] [opentelemetry bump fails to build](https://github.com/NixOS/nixpkgs/pull/357386)
- [x] ~[mongodb fails to compile on macOS](https://github.com/NixOS/nixpkgs/issues/346003) [PR]~ (https://github.com/NixOS/nixpkgs/pull/358063) switched to mongodb-ce
- [x] [bun build hangs generating completions on x86. Wait for 1.1.35 to be released. Rosetta no longer supported. Old macOS versions not supported](https://github.com/NixOS/nixpkgs/pull/358195)
- [x] [zls fails on macOS](https://github.com/NixOS/nixpkgs/issues/290102)
- [x] poetry fails to work with Python wrapper. Fixed by bumping poetry.lock.
- [x] deno fails to compile until macOS SDK is bumped
- [x] [swift fails to compile until macOS SDK is bumped](https://github.com/NixOS/nixpkgs/pull/346947)
- [x] [meilisearch fails to build on macOS X86](https://github.com/NixOS/nixpkgs/pull/357277)
- [x] [rabbitmq crashes trying to run `ps`. `"ps -p 17165 -o rss=", "ps: rss: requires entitlement"`](https://github.com/NixOS/nixpkgs/pull/357337)
