### PR TITLE
Stop CI from failing

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
Hi, CI has been failing for over a month now:

`(refusing to allow a GitHub App to create or update workflow `.github/workflows/backport.yml` without `workflows` permission)`

This PR fixes that issue by giving the workflow that `workflows` permission.