### PR TITLE
patches: bump prek to 0.3.9

### DIFF
--- a/patches/default.nix
+++ b/patches/default.nix
@@ -31,6 +31,13 @@ in
 {
   # Patches from nixpkgs PRs or unreleased fixes
   upstream = [
+    # Bump prek to 0.3.9 so rolling includes repo/worktree-scoped
+    # core.hooksPath support before nixpkgs-unstable catches up.
+    (fetchpatch {
+      name = "prek-0.3.9.patch";
+      url = "https://github.com/NixOS/nixpkgs/commit/8568fa964f10d795abdce4cf96a501f43b0efad5.patch";
+      sha256 = "sha256-ALeLmuiPYeNmI6GNgaDSnAfu5Nd152rUnk9pPCUS1jY=";
+    })
   ]
   ++ lib.optionals isDarwin [
   ];


### PR DESCRIPTION
## Summary

`nixpkgs-unstable` has not picked up `NixOS/nixpkgs#509787` yet, so `cachix/devenv-nixpkgs/main` and `rolling` still expose `prek 0.3.8`.

This adds the already-merged nixpkgs commit as an upstream patch so `devenv-nixpkgs` can ship `prek 0.3.9` before the next unstable import catches up.

Upstream merge commit:
- `8568fa964f10d795abdce4cf96a501f43b0efad5`
- `NixOS/nixpkgs#509787`

Why this matters for `devenv`:
- `prek 0.3.9` includes repo/worktree `core.hooksPath` support
- that unblocks dropping the temporary git-hooks wrapper in `cachix/devenv` once `rolling` includes this version

## Validation

On this host:

- `nix eval --impure --expr 'let flake = builtins.getFlake (toString ./.); system = builtins.currentSystem; in flake.legacyPackages.${system}.prek.version' --json`
  - returns `0.3.9`
- `nix build .#legacyPackages.$(nix eval --impure --expr builtins.currentSystem --raw).hello --no-link`
- `nix build .#legacyPackages.$(nix eval --impure --expr builtins.currentSystem --raw).prek --no-link`

I could not run the repo's exact `x86_64-linux` validation build locally from this `aarch64-darwin` host because no Linux builder is configured.
